### PR TITLE
Use and convert feathers-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "can": "^2.3.16",
     "cookie-storage": "^1.0.4",
+    "feathers-errors": "^2.1.0",
     "jquery": "^2.2.3",
     "jwt-decode": "^2.0.1",
     "steal-socket.io": "^2.0.3"


### PR DESCRIPTION
This pull request returns an actual promise for `makeRequest` and converts applicable responses to [feathers-errors](http://docs.feathersjs.com/middleware/error-handling.html).