### PR TITLE
Added support for adding idProp as part of the URL rather than params

### DIFF
--- a/src/can-connect-feathers.js
+++ b/src/can-connect-feathers.js
@@ -94,6 +94,12 @@ class Feathers {
     if (id !== null && id !== undefined) {
       url += `/${id}`;
     }
+    else if (params[this.idProp]) {
+      url += `/${params[this.idProp]}`;
+      // remove the property from the params so that
+      // it is not passed as query string
+      delete params[this.idProp];
+    }
 
     let contentType = 'application/x-www-form-urlencoded';
     if (type !== 'GET') {


### PR DESCRIPTION
@marshallswain: I have added support for correctly passing the idProp as part of the URL instead of parameters. 